### PR TITLE
[TASK] Docker implementation for database commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
-# db-t3kit
+# t3kit_db
+
+[![Release](https://img.shields.io/github/release/t3kit/t3kit_db.svg?style=flat-square)](https://github.com/t3kit/t3kit_db/releases)
 
 Just to make the t3kit TYPO3 database available for other projects.
 
-This is a version that can be used with DockerT3kit wrapper.
+### [CHANGELOG](https://github.com/t3kit/t3kit_db/blob/master/CHANGELOG.md)
+### [CONTRIBUTING](https://github.com/t3kit/t3kit/blob/master/CONTRIBUTING.md)
 
 
 ### To update database dump
 Run
-```shell
-packdb.sh
-```
-from inside the db docker container to generate dump. It will dump the database to a file, parameters are specified in the script. It will clear be_users and som  other tables from the dump. It will merge the be_users.sql into the dump to create only be_users from this dump. Currently admin - admin1234 and cli_scheduler.
+
+    packdb.sh
+
+from inside the vagrant vm or docker container to generate dump. It will dump the database to a file, parameters are specified in the script. It will clear be_users and som  other tables from the dump. It will merge the be_users.sql into the dump to create only be_users from this dump. Currently admin - admin1234 and cli_scheduler.
 Commit and push from local filesystem.
 
 ### To update be_users table
 Run
-```shell
-create_new_beusers_sql.sh
-```
-from inside the db docker container before running pack.db
+
+    create_new_beusers_sql.sh
+
+from inside the vagrant vm or docker container before running pack.db
 
 ### To restore database
 Run
-```shell
-restoredb.sh
-```
-from inside the the db docker container to restore database
 
+    restoredb.sh
+    
+from inside the vagrant vm or docker container to restore database

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # db-t3kit
 
-[![Release](https://img.shields.io/github/release/t3kit/t3kit_db.svg?style=flat-square)](https://github.com/t3kit/t3kit_db/releases)
-
 Just to make the t3kit TYPO3 database available for other projects.
 
-### [CHANGELOG](https://github.com/t3kit/t3kit_db/blob/master/CHANGELOG.md)
-### [CONTRIBUTING](https://github.com/t3kit/t3kit/blob/master/CONTRIBUTING.md)
+This is a version that can be used with DockerT3kit wrapper.
 
 
 ### To update database dump
@@ -13,7 +10,7 @@ Run
 ```shell
 packdb.sh
 ```
-from inside the vagrant vm to generate dump. It will dump the database to a file, parameters are specified in the script. It will clear be_users and som  other tables from the dump. It will merge the be_users.sql into the dump to create only be_users from this dump. Currently admin - admin1234 and cli_scheduler.
+from inside the db docker container to generate dump. It will dump the database to a file, parameters are specified in the script. It will clear be_users and som  other tables from the dump. It will merge the be_users.sql into the dump to create only be_users from this dump. Currently admin - admin1234 and cli_scheduler.
 Commit and push from local filesystem.
 
 ### To update be_users table
@@ -21,11 +18,12 @@ Run
 ```shell
 create_new_beusers_sql.sh
 ```
-from inside the vagrant vm before running pack.db
+from inside the db docker container before running pack.db
 
 ### To restore database
 Run
 ```shell
 restoredb.sh
 ```
-from inside the vagrant vm to restore database
+from inside the the db docker container to restore database
+

--- a/create_new_beusers_sql.sh
+++ b/create_new_beusers_sql.sh
@@ -1,1 +1,1 @@
-mysqldump -uroot -p1234 t3kit be_users > be_users.sql
+mysqldump -hdb -uroot -proot dockertypo3 be_users > be_users.sql

--- a/create_new_beusers_sql.sh
+++ b/create_new_beusers_sql.sh
@@ -1,1 +1,11 @@
-mysqldump -hdb -uroot -proot dockertypo3 be_users > be_users.sql
+#!/bin/bash
+
+USERNAME="t3kit"
+PASSWORD="t3kit1234"
+DATABASE="t3kit"
+
+if [ -f "/.dockerenv" ]; then
+	mysqldump -hdb -u"$USERNAME" -p"$PASSWORD" "$DATABASE" be_users > /var/www/shared/db/be_users.sql
+else
+	mysqldump -u"$USERNAME" -p"$PASSWORD" "$DATABASE" be_users > be_users.sql
+fi

--- a/packdb.sh
+++ b/packdb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-DB_DB="t3kit"
-DB_USER="t3kit"
-DB_PW="t3kit1234"
+DB_DB="dockertypo3"
+DB_USER="root"
+DB_PW="root"
 OUT_FILE=${1:-"t3kit.sql"}
 
 CLEAR_TABLES=(
@@ -48,11 +48,11 @@ CLEAR_TABLES=(
 echo "Clearing tables...";
 for TABLE in "${CLEAR_TABLES[@]}"
 do
-	mysql -u "$DB_USER" -p"$DB_PW" -e "TRUNCATE TABLE ${TABLE}" "$DB_DB" 
+	mysql -hdb -u "$DB_USER" -p"$DB_PW" -e "TRUNCATE TABLE ${TABLE}" "$DB_DB"
 done
 
 echo "Dumping db..."
-mysqldump -u "$DB_USER" -p"$DB_PW" "$DB_DB" > "$OUT_FILE"
+mysqldump -hdb -u "$DB_USER" -p"$DB_PW" "$DB_DB" > "$OUT_FILE"
 
 echo "Output in ${OUT_FILE}"
 

--- a/packdb.sh
+++ b/packdb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-DB_DB="dockertypo3"
-DB_USER="root"
-DB_PW="root"
+DB_DB="t3kit"
+DB_USER="t3kit"
+DB_PW="t3kit1234"
 OUT_FILE=${1:-"t3kit.sql"}
 
 CLEAR_TABLES=(
@@ -48,13 +48,25 @@ CLEAR_TABLES=(
 echo "Clearing tables...";
 for TABLE in "${CLEAR_TABLES[@]}"
 do
+	if [ -f "/.dockerenv" ]; then
 	mysql -hdb -u "$DB_USER" -p"$DB_PW" -e "TRUNCATE TABLE ${TABLE}" "$DB_DB"
+	else
+	mysql -u "$DB_USER" -p"$DB_PW" -e "TRUNCATE TABLE ${TABLE}" "$DB_DB"
+	fi
 done
 
 echo "Dumping db..."
-mysqldump -hdb -u "$DB_USER" -p"$DB_PW" "$DB_DB" > "$OUT_FILE"
+	if [ -f "/.dockerenv" ]; then
+	mysqldump -hdb -u "$DB_USER" -p"$DB_PW" "$DB_DB" > /var/www/shared/db/"$OUT_FILE"
+	else
+	mysqldump -u "$DB_USER" -p"$DB_PW" "$DB_DB" > "$OUT_FILE"
+	fi
 
 echo "Output in ${OUT_FILE}"
 
 echo "Merge be_users.sql dump, must include admin user with password admin1234"
-cat be_users.sql >> "${OUT_FILE}"
+	if [ -f "/.dockerenv" ]; then
+	cat /var/www/shared/db/be_users.sql >> "/var/www/shared/db/${OUT_FILE}"
+	else
+	cat be_users.sql >> "${OUT_FILE}"
+	fi

--- a/restoredb.sh
+++ b/restoredb.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
 
-PASSWORD="t3kit1234"
-DATABASE="t3kit"
-USERNAME="t3kit"
+PASSWORD="root"
+DATABASE="dockertypo3"
+USERNAME="root"
 
-mysql -uroot -p1234 -e "SHOW DATABASES;"
+mysql -hdb -u"$USERNAME" -p""$PASSWORD"" -e "SHOW DATABASES;"
 echo -e "Dropping a database $DATABASE... \r10% "
-mysql -uroot -p1234 -e "DROP DATABASE $DATABASE;"
+mysql -hdb -u"$USERNAME" -p"$PASSWORD" -e "DROP DATABASE $DATABASE;"
 
 echo -e "Installing DB $DATABASE... \r40% "
-mysql -uroot -p1234 -e "CREATE DATABASE IF NOT EXISTS $DATABASE CHARACTER SET utf8 COLLATE utf8_swedish_ci;"
-mysql -uroot -p1234 -e "GRANT ALL PRIVILEGES ON $DATABASE.* TO '$USERNAME'@localhost IDENTIFIED BY '$PASSWORD';"
-mysql -uroot -p1234 $DATABASE < /var/www/shared/db/$DATABASE.sql
+mysql -hdb -u"$USERNAME" -p"$PASSWORD" -e "CREATE DATABASE IF NOT EXISTS $DATABASE CHARACTER SET utf8 COLLATE utf8_swedish_ci;"
+mysql -hdb -u"$USERNAME" -p"$PASSWORD" -e "GRANT ALL PRIVILEGES ON $DATABASE.* TO '$USERNAME'@localhost IDENTIFIED BY '$PASSWORD';"
+mysql -hdb -u"$USERNAME" -p"$PASSWORD" $DATABASE < /var/www/shared/db/t3kit.sql
 
-echo -e "Restarting MySQL... \r60% "
-service mysql restart > /dev/null 2>&1
-echo -e "Restarting Apache... \r85% "
-service apache2 restart > /dev/null 2>&1

--- a/restoredb.sh
+++ b/restoredb.sh
@@ -1,15 +1,22 @@
 #!/bin/bash
 
-PASSWORD="root"
-DATABASE="dockertypo3"
+PASSWORD="1234"
+DATABASE="t3kit"
 USERNAME="root"
+T3KIT_USER="t3kit"
+T3KIT_PASSWORD="t3kit1234"
 
-mysql -hdb -u"$USERNAME" -p""$PASSWORD"" -e "SHOW DATABASES;"
+if [ -n "${DOCKER}" ]; then
+  DBHOST="db"
+else
+  DBHOST="localhost"
+fi
+mysql -h${DBHOST} -u"$USERNAME" -p""$PASSWORD"" -e "SHOW DATABASES;"
 echo -e "Dropping a database $DATABASE... \r10% "
-mysql -hdb -u"$USERNAME" -p"$PASSWORD" -e "DROP DATABASE $DATABASE;"
+mysql -h${DBHOST} -u"$USERNAME" -p"$PASSWORD" -e "DROP DATABASE $DATABASE;"
 
 echo -e "Installing DB $DATABASE... \r40% "
-mysql -hdb -u"$USERNAME" -p"$PASSWORD" -e "CREATE DATABASE IF NOT EXISTS $DATABASE CHARACTER SET utf8 COLLATE utf8_swedish_ci;"
-mysql -hdb -u"$USERNAME" -p"$PASSWORD" -e "GRANT ALL PRIVILEGES ON $DATABASE.* TO '$USERNAME'@localhost IDENTIFIED BY '$PASSWORD';"
-mysql -hdb -u"$USERNAME" -p"$PASSWORD" $DATABASE < /var/www/shared/db/t3kit.sql
+mysql -h${DBHOST} -u"$USERNAME" -p"$PASSWORD" -e "CREATE DATABASE IF NOT EXISTS $DATABASE CHARACTER SET utf8 COLLATE utf8_swedish_ci;"
+mysql -h${DBHOST} -u"$USERNAME" -p"$PASSWORD" -e "GRANT ALL PRIVILEGES ON $DATABASE.* TO '$T3KIT_USER'@localhost IDENTIFIED BY '$T3KIT_PASSWORD';"
+mysql -h${DBHOST} -u"$USERNAME" -p"$PASSWORD" $DATABASE < /var/www/shared/db/t3kit.sql
 

--- a/restoredb.sh
+++ b/restoredb.sh
@@ -20,3 +20,9 @@ mysql -h${DBHOST} -u"$USERNAME" -p"$PASSWORD" -e "CREATE DATABASE IF NOT EXISTS 
 mysql -h${DBHOST} -u"$USERNAME" -p"$PASSWORD" -e "GRANT ALL PRIVILEGES ON $DATABASE.* TO '$T3KIT_USER'@localhost IDENTIFIED BY '$T3KIT_PASSWORD';"
 mysql -h${DBHOST} -u"$USERNAME" -p"$PASSWORD" $DATABASE < /var/www/shared/db/t3kit.sql
 
+if [ ! -n "${DOCKER}" ]; then
+	-echo -e "Restarting MySQL... \r60% "
+	-service mysql restart > /dev/null 2>&1
+	-echo -e "Restarting Apache... \r85% "
+	-service apache2 restart > /dev/null 2>&1
+fi


### PR DESCRIPTION
Add Docker implementation for the sample database.

Shell script commands launch the database operations based on the environment. In the Docker containers few things need to be done differently. Same commands can be used both in Vagrant and Docker. 
